### PR TITLE
Made GetRemoteBuild(), Install() and Update() functions compatible with Paper APIv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-﻿################################################################################
-# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
-################################################################################
-
-/.vs/WindowsGSM.PaperMC/v16/.suo
-/.vs/slnx.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs/WindowsGSM.PaperMC/v16/.suo
+/.vs/slnx.sqlite

--- a/PaperMC.cs/PaperMC.cs
+++ b/PaperMC.cs/PaperMC.cs
@@ -172,15 +172,21 @@ namespace WindowsGSM.Plugins
             }
 
             // Try getting the latest version and build
-            var build = await GetRemoteBuild(); // "1.16.1/133"
-            if (string.IsNullOrWhiteSpace(build)) { return null; }
+            /// var build = await GetRemoteBuild(); // "1.16.1/133"
+            var build = (await GetRemoteBuild()).Split('/'); // [0]="1.16.1", [1]="133"
+            /// if (string.IsNullOrWhiteSpace(build)) { return null; }
+            if (build.Length<2) { return null; }
 
             // Download the latest paper.jar to /serverfiles
             try
             {
                 using (var webClient = new WebClient())
                 {
-                    await webClient.DownloadFileTaskAsync($"https://papermc.io/api/v1/paper/{build}/download", ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath));
+                    var downloadName = JObject.Parse(await webClient.DownloadStringTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}"))["downloads"]["application"]["name"].ToString(); // "paper-1.20.4-424.jar"
+                    /// /*Debug only*/ await UI.CreateYesNoPromptV1("Variables2", $"Download name: {downloadName}", "OK", "OK");
+                    /// /*Debug only*/ await UI.CreateYesNoPromptV1("Variables2", $"URL:\nhttps://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}/downloads/{downloadName}", "OK", "OK");
+                    await webClient.DownloadFileTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}/downloads/{downloadName}", ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath));
+                    /// await webClient.DownloadFileTaskAsync($"https://papermc.io/api/v1/paper/{build}/download", ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath));
                 }
             }
             catch (Exception e)
@@ -287,13 +293,14 @@ namespace WindowsGSM.Plugins
         // - Get Latest server version
         public async Task<string> GetRemoteBuild()
         {
-            // Get latest version and build at https://papermc.io/api/v1/paper
+            // Get latest version and build at https://api.papermc.io
             try
             {
                 using (var webClient = new WebClient())
                 {
-                    var version = JObject.Parse(await webClient.DownloadStringTaskAsync("https://papermc.io/api/v1/paper"))["versions"][0].ToString(); // "1.16.1"
-                    var build = JObject.Parse(await webClient.DownloadStringTaskAsync($"https://papermc.io/api/v1/paper/{version}"))["builds"]["latest"].ToString(); // "133"
+                    var version = JObject.Parse(await webClient.DownloadStringTaskAsync("https://api.papermc.io/v2/projects/paper"))["versions"].Last.ToString(); // "1.16.1"
+                    var build = JObject.Parse(await webClient.DownloadStringTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{version}"))["builds"].Last.ToString(); // "133"
+                    /// /*Debug only*/ await UI.CreateYesNoPromptV1("Variables", $"Version collected: {version}\nBuild collected: {build}", "OK", "OK");
                     return $"{version}/{build}";
                 }
             }

--- a/PaperMC.cs/PaperMC.cs
+++ b/PaperMC.cs/PaperMC.cs
@@ -172,9 +172,7 @@ namespace WindowsGSM.Plugins
             }
 
             // Try getting the latest version and build
-            /// var build = await GetRemoteBuild(); // "1.16.1/133"
             var build = (await GetRemoteBuild()).Split('/'); // [0]="1.16.1", [1]="133"
-            /// if (string.IsNullOrWhiteSpace(build)) { return null; }
             if (build.Length<2) { return null; }
 
             // Download the latest paper.jar to /serverfiles
@@ -183,10 +181,7 @@ namespace WindowsGSM.Plugins
                 using (var webClient = new WebClient())
                 {
                     var downloadName = JObject.Parse(await webClient.DownloadStringTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}"))["downloads"]["application"]["name"].ToString(); // "paper-1.20.4-424.jar"
-                    /// /*Debug only*/ await UI.CreateYesNoPromptV1("Variables2", $"Download name: {downloadName}", "OK", "OK");
-                    /// /*Debug only*/ await UI.CreateYesNoPromptV1("Variables2", $"URL:\nhttps://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}/downloads/{downloadName}", "OK", "OK");
                     await webClient.DownloadFileTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}/downloads/{downloadName}", ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath));
-                    /// await webClient.DownloadFileTaskAsync($"https://papermc.io/api/v1/paper/{build}/download", ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath));
                 }
             }
             catch (Exception e)
@@ -229,15 +224,16 @@ namespace WindowsGSM.Plugins
             }
 
             // Try getting the latest version and build
-            var build = await GetRemoteBuild(); // "1.16.1/133"
-            if (string.IsNullOrWhiteSpace(build)) { return null; }
+            var build = (await GetRemoteBuild()).Split('/'); // [0]="1.16.1", [1]="133"
+            if (build.Length < 2) { return null; }
 
             // Download the latest paper.jar to /serverfiles
             try
             {
                 using (var webClient = new WebClient())
                 {
-                    await webClient.DownloadFileTaskAsync($"https://papermc.io/api/v1/paper/{build}/download", ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath));
+                    var downloadName = JObject.Parse(await webClient.DownloadStringTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}"))["downloads"]["application"]["name"].ToString(); // "paper-1.20.4-424.jar"
+                    await webClient.DownloadFileTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{build[0]}/builds/{build[1]}/downloads/{downloadName}", ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath));
                 }
             }
             catch (Exception e)
@@ -300,7 +296,6 @@ namespace WindowsGSM.Plugins
                 {
                     var version = JObject.Parse(await webClient.DownloadStringTaskAsync("https://api.papermc.io/v2/projects/paper"))["versions"].Last.ToString(); // "1.16.1"
                     var build = JObject.Parse(await webClient.DownloadStringTaskAsync($"https://api.papermc.io/v2/projects/paper/versions/{version}"))["builds"].Last.ToString(); // "133"
-                    /// /*Debug only*/ await UI.CreateYesNoPromptV1("Variables", $"Version collected: {version}\nBuild collected: {build}", "OK", "OK");
                     return $"{version}/{build}";
                 }
             }


### PR DESCRIPTION
Updated to make GetRemoteBuild(), Install() and Update() functions compatible with Paper APIv2. Many thanks to @Raziel7893 for support.